### PR TITLE
Feature/popup mods

### DIFF
--- a/src/components/MapPopup/MapPopup.js
+++ b/src/components/MapPopup/MapPopup.js
@@ -124,17 +124,35 @@ const MapPopup = props => {
   }
 
   const _build = (config, event) => {
-    new Popup()
-      .setLngLat(event.lngLat)
-      .setHTML(
-        ReactDOMServer.renderToString(
-          <Container
-            properties={event.features[0].properties}
-            config={config}
-          />
+    if(config.intercept) {
+      config.intercept(event.features[0].properties).then(function (properties) {
+        new Popup()
+        .setLngLat(event.lngLat)
+        .setHTML(
+          ReactDOMServer.renderToString(
+            <Container
+              properties={properties}
+              config={config}
+            />
+          )
         )
-      )
-      .addTo(map);
+        .addTo(map);
+      }).catch(function (err) {
+        console.warn(err);
+      })
+    } else {
+      new Popup()
+        .setLngLat(event.lngLat)
+        .setHTML(
+          ReactDOMServer.renderToString(
+            <Container
+              properties={event.features[0].properties}
+              config={config}
+            />
+          )
+        )
+        .addTo(map);
+    }
   };
 
   // register map click event for popup

--- a/src/components/MapPopup/MapPopup.js
+++ b/src/components/MapPopup/MapPopup.js
@@ -9,7 +9,11 @@ const Container = props => {
   const { styles, properties, config } = props;
   return (
     <Box className="popup-container">
-      <Title properties={properties} config={config.title} />
+      {
+        (config.title && config.title.field) ? 
+          <Title properties={properties} config={config.title} /> :
+          null
+      }
       <List style={styles} properties={properties} config={config.attributes} />
     </Box>
   );
@@ -17,6 +21,7 @@ const Container = props => {
 
 const Title = props => {
   const { properties, config } = props;
+  if(!properties.hasOwnProperty(config.field)) return null;
   return (
     <Box
       {...props}

--- a/src/components/MapPopup/MapPopup.stories.js
+++ b/src/components/MapPopup/MapPopup.stories.js
@@ -19,11 +19,25 @@ const popupLayers = [
     title: {
       field: 'name'
     }, // popup title field
+    intercept: function (properties) {
+      console.log(properties)
+      // mock getting some external data
+      return new Promise(function (resolve, reject) {
+        setTimeout(function () {
+          resolve(Object.assign(properties, {'source': 'intercept'}))
+        }, 250)
+      })
+    },
     attributes: [
       {
         field: 'wikipedia', // original field name
         label: 'Wiki', // desired label
         type: 'link' // text, link, image
+      },
+      {
+         field: 'source',
+         label: 'Source',
+         type: 'text',
       },
       {
         field: 'postal',

--- a/src/components/MapPopup/MapPopup.stories.js
+++ b/src/components/MapPopup/MapPopup.stories.js
@@ -20,7 +20,6 @@ const popupLayers = [
       field: 'name'
     }, // popup title field
     intercept: function (properties) {
-      console.log(properties)
       // mock getting some external data
       return new Promise(function (resolve, reject) {
         setTimeout(function () {


### PR DESCRIPTION
1) Adds intercept method to MapPopup, which will allow us to inject new content into popup by returning a Promise with anything.  This will allow us to get popup data based on external API calls, etc.
2) If no title property is provided OR if title is empty in resulting map click feature, the title component is removed from MapPopup.