### PR TITLE
fix: ignore legend logic if not requested

### DIFF
--- a/src/components/LayerList/LayerListItem.js
+++ b/src/components/LayerList/LayerListItem.js
@@ -47,11 +47,13 @@ const LayerListItem = ({
           layerVisibility = map.getLayoutProperty(layerIds[0], 'visibility');
           checked = layerVisibility === 'none' ? false : true;
           setIsChecked(checked);
-          setStyle(
-            layerInfo.legendStyle
-              ? layerInfo.legendStyle()
-              : buildStyle(map.getLayer(layerIds[0]))
-          );
+          if(legend) {
+            setStyle(
+              layerInfo.legendStyle
+                ? layerInfo.legendStyle()
+                : buildStyle(map.getLayer(layerIds[0]))
+            );
+          }
         });
       }
     }
@@ -76,12 +78,16 @@ const LayerListItem = ({
           {actionMenuSlot}
         </Flex>
       </ListItem>
-      <ListItem
-        css={{ display: legend && style ? '' : 'none' }}
-        key={layerInfo.layerName + '-legend'}
-      >
-        {style}
-      </ListItem>
+      {(legend) ? 
+        <ListItem
+          css={{ display: legend && style ? '' : 'none' }}
+          key={layerInfo.layerName + '-legend'}
+        >
+          {style}
+        </ListItem>
+        :
+        null
+      }
     </Box>
   );
 };


### PR DESCRIPTION
This is an initial fix for our layer list issues.  Previously, legend logic was being called even if legend wasn't requested in the LayerList component.  Now, it's ignored if legend=false.  Does not resolve other issues (data driven styles, etc), but will suppress errors when legend not needed.