### PR TITLE
chore: fix legend rerender on idle

### DIFF
--- a/src/components/LayerList/LayerListItem.js
+++ b/src/components/LayerList/LayerListItem.js
@@ -35,7 +35,7 @@ const LayerListItem = ({
     let layerVisibility, checked;
     if (mapExists(map)) {
       if (Object.keys(map).length > 0) {
-        map.on('idle', () => {
+        map.once('idle', () => {
           layerVisibility = map.getLayoutProperty(layerIds[0], 'visibility');
           checked = layerVisibility === 'none' ? false : true;
           setIsChecked(checked);


### PR DESCRIPTION
Fixes multiple <Legend /> component rerender based on `map.on('idle')`.  Instead doing single event `map.once`.