### PR TITLE
feat: add ability to set popup actions menu to loading from action

### DIFF
--- a/src/components/MapPopup/MapPopup.stories.js
+++ b/src/components/MapPopup/MapPopup.stories.js
@@ -13,8 +13,6 @@ const customMapOptions = Object.assign({}, mapOptions, {
   zoom: 3
 });
 
-var tmp = ">>>";
-
 const popupLayers = [
   {
     layerId: 'states-layer', // id of layer on map

--- a/src/components/MapPopup/MapPopup.stories.js
+++ b/src/components/MapPopup/MapPopup.stories.js
@@ -13,6 +13,8 @@ const customMapOptions = Object.assign({}, mapOptions, {
   zoom: 3
 });
 
+var tmp = ">>>";
+
 const popupLayers = [
   {
     layerId: 'states-layer', // id of layer on map
@@ -62,10 +64,14 @@ const popupLayers = [
     actions: [
       {
         title: 'Custom Action',
-        action: feature => {
-          alert(
-            `${feature.properties.name} in the "${feature.layer.id}" map layer `
-          );
+        action: (feature, setLoading) => {
+          setLoading(true);
+          setTimeout(() => {
+            alert(
+              `${feature.properties.name} in the "${feature.layer.id}" map layer `
+            );
+            setLoading(false);
+          }, 1500)
         }
       }
     ]

--- a/src/components/MapPopup/PopupActionsMenu.js
+++ b/src/components/MapPopup/PopupActionsMenu.js
@@ -1,5 +1,7 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui';
+import { useState } from 'react';
+import { Spinner } from '@theme-ui/components';
 import {
   Menu,
   MenuButton,
@@ -14,6 +16,8 @@ import '@reach/menu-button/styles.css';
 */
 
 const PopupActionsMenu = ({ feature, popupActions }) => {
+  const [loading, setLoading] = useState(false);
+
   if (popupActions && popupActions.length > 0) {
     return (
       <Menu className="cl-popup-action-menu">
@@ -26,7 +30,7 @@ const PopupActionsMenu = ({ feature, popupActions }) => {
             float: 'right'
           }}
         >
-          ...
+          {(loading) ? <Spinner size={14} /> : '...'}
         </MenuButton>
         <MenuPopover sx={{ zIndex: 3, fontFamily: 'roboto, sans-serif' }}>
           {' '}
@@ -37,7 +41,7 @@ const PopupActionsMenu = ({ feature, popupActions }) => {
                 <MenuItem
                   key={action.title}
                   onSelect={() => {
-                    action.action(feature);
+                    action.action(feature, setLoading);
                   }}
                 >
                   {action.title}


### PR DESCRIPTION
This adds the ability to update state of parent action menu `setLoading(boolean)` from within an action config.  We can now show loading indicator for long running processes.