### PR TITLE
chore: set minimum size for data driven constant circle-radius

### DIFF
--- a/src/components/LayerList/Legend.js
+++ b/src/components/LayerList/Legend.js
@@ -151,7 +151,8 @@ const buildStyle = lyr => {
     // Is circle-radius a data driven paint style?
     if (
       paint.get('circle-radius').value._parameters &&
-      paint.get('circle-radius').value._parameters.hasOwnProperty('stops')
+      paint.get('circle-radius').value._parameters.hasOwnProperty('stops') &&
+      paint.get('circle-radius').value.kind === 'source'
     ) {
       flexGrow = 6;
       textAlign = 'center';
@@ -160,6 +161,9 @@ const buildStyle = lyr => {
       flexGrow = 1;
       textAlign = 'left';
       cr = [paint.get('circle-radius').value.value.toString()];
+      if(+cr[0] < 8) {
+        cr = ["8"];
+      }
     }
 
     const Items = () => {

--- a/src/util/mockMapLayers.js
+++ b/src/util/mockMapLayers.js
@@ -31,8 +31,15 @@ const dcArtLayer = {
       'https://raw.githubusercontent.com/benbalter/dc-maps/master/maps/washington-dc-public-art.geojson'
   },
   paint: {
-    'circle-radius': 8,
-    'circle-color': '#B42222'
+    'circle-color': '#B42222',
+    'circle-radius': {
+      stops: [
+        [8, 3],
+        [12, 4],
+        [16, 5],
+        [18, 6]
+      ]
+    }
   }
 };
 


### PR DESCRIPTION
Data driven circle-radius based on zoom level defaults to a constant size based on initial zoom level, which is usually a very small circle.  Then circle-radius is below a threshold of size 8, legend circle radius will default to the size 8 minimum.