### PR TITLE
feat: add intercept prop to <Home />

### DIFF
--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -12,10 +12,37 @@ const Home = ({
   initZoom,
   initPitch,
   initBearing,
+  intercept,
   ...rest
 }) => {
   const config = useContext(Context);
   const { map } = config;
+
+  const zoomToHome = () => {
+    if (initBounds) {
+      try {
+        map.fitBounds(initBounds);
+        map.setPitch(initPitch ?? 0);
+        map.setBearing(initBearing ?? 0);
+      } catch (err) {
+        console.error(err);
+      }
+    } else if (initCenter && initZoom) {
+      try {
+        map.setCenter(initCenter);
+        map.setZoom(initZoom);
+        map.setPitch(initPitch ?? 0);
+        map.setBearing(initBearing ?? 0);
+      } catch (err) {
+        console.error(err);
+      }
+    } else {
+      console.error(
+        'Home Button Error: required props are not present. Make sure you pass "initBounds" OR "initCenter" and "initZoom".'
+      );
+    }
+  };
+
   return (
     <BaseComponent {...rest} className="cl-home-button">
       <Button
@@ -25,27 +52,19 @@ const Home = ({
         data-testid="home-button"
         onClick={() => {
           if (mapExists(map)) {
-            if (initBounds) {
+            if (intercept) {
               try {
-                map.fitBounds(initBounds);
-                map.setPitch(initPitch ?? 0);
-                map.setBearing(initBearing ?? 0);
-              } catch (err) {
-                console.error(err);
-              }
-            } else if (initCenter && initZoom) {
-              try {
-                map.setCenter(initCenter);
-                map.setZoom(initZoom);
-                map.setPitch(initPitch ?? 0);
-                map.setBearing(initBearing ?? 0);
-              } catch (err) {
-                console.error(err);
+                if (Array.isArray(intercept)) {
+                  intercept[0](map);
+                  if (intercept[1]) { zoomToHome() };
+                } else {
+                  intercept();
+                }
+              } catch (interceptError) {
+                zoomToHome();
               }
             } else {
-              console.error(
-                'Home Button Error: required props are not present. Make sure you pass "initBounds" OR "initCenter" and "initZoom".'
-              );
+              zoomToHome();
             }
           }
         }}

--- a/src/components/Home/Home.stories.js
+++ b/src/components/Home/Home.stories.js
@@ -16,4 +16,36 @@ storiesOf('Home', module)
         <Home initCenter={mapOptions.center} initZoom={mapOptions.zoom} />
       </ElementsProvider>
     );
+  })
+  .add('Intercept With Standard Zoom', () => {
+    const intercept = () => {
+      alert('Intercepting, now zoom in to home!');
+    };
+    return (
+      <ElementsProvider>
+        <Map mapOptions={mapOptions} />
+        <Home initCenter={mapOptions.center} initZoom={mapOptions.zoom} intercept={[intercept, true]} />
+      </ElementsProvider>
+    );
+  })
+  .add('Intercept With Custom Zoom', () => {
+    const intercept = (map) => {
+      map.flyTo({
+        center: mapOptions.center,
+        zoom: mapOptions.zoom,
+        bearing: mapOptions.bearing ?? 0,
+        speed: 1.7,
+        curve: 1.7,
+        easing: function(t) {
+          return t;
+        },
+        essential: true
+      });
+    };
+    return (
+      <ElementsProvider>
+        <Map mapOptions={mapOptions} />
+        <Home initCenter={mapOptions.center} initZoom={mapOptions.zoom} intercept={[intercept, false]} />
+      </ElementsProvider>
+    );
   });


### PR DESCRIPTION
I added an intercept prop that accepts either:

A: an intercept function <Home intercept={(map) => { }) />

B: an array with an intercept function [0] and Falsey Boolean [1] <Home intercept={[(map) => { }, False]} />

Here, A and B have the same result.  The Boolean determines if the standard zoomTo logic is run.   I have an example where we instead pass in a function that uses the flyTo function.

C: an array with an intercept function [0] and Truty Boolean [1] <Home intercept={[(map) => { }, True]} />

C will run the standard zoomTo logic and the function just acts as a callback.

All intercept functions will return the map object.