### PR TITLE
fix: working <Home /> initBounds with documented story

### DIFF
--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -21,9 +21,9 @@ const Home = ({
   const zoomToHome = () => {
     if (initBounds) {
       try {
-        map.fitBounds(initBounds);
         map.setPitch(initPitch ?? 0);
         map.setBearing(initBearing ?? 0);
+        map.fitBounds(initBounds);
       } catch (err) {
         console.error(err);
       }

--- a/src/components/Home/Home.stories.js
+++ b/src/components/Home/Home.stories.js
@@ -9,6 +9,14 @@ import mapOptions from '../../util/mockMapOptions';
 
 storiesOf('Home', module)
   .addDecorator(withKnobs)
+  .add('Using Bounds', () => {
+    return (
+      <ElementsProvider>
+        <Map mapOptions={mapOptions} />
+        <Home initBounds={mapOptions.bounds} />
+      </ElementsProvider>
+    );
+  })
   .add('Using Zoom and Center', () => {
     return (
       <ElementsProvider>

--- a/src/util/mockMapOptions.js
+++ b/src/util/mockMapOptions.js
@@ -3,6 +3,7 @@ import config from '../config';
 const mapOptions = {
   container: 'map',
   style: 'mapbox://styles/mapbox/streets-v11',
+  bounds: [[-96.1642,29.7381],[-95.3841,29.8781]],
   center: [-95.7742, 29.80814],
   zoom: 10,
   accessToken: config.mapboxToken


### PR DESCRIPTION
For map.fitBounds(), pitch and bearing must be specified prior for method to work.