### PR TITLE
fix: resolve layerList checkbox and legend state for baseType = button

### DIFF
--- a/src/components/LayerList/LayerList.js
+++ b/src/components/LayerList/LayerList.js
@@ -33,6 +33,7 @@ const LayerList = ({
         itemActions={item.actions}
         showActions={showActions}
         checkboxStyle={checkboxStyle}
+        baseType={baseType}
       />
     );
   });

--- a/src/components/LayerList/LayerList.stories.js
+++ b/src/components/LayerList/LayerList.stories.js
@@ -196,6 +196,18 @@ storiesOf('LayerList', module)
       </ElementsProvider>
     );
   })
+  .add('With Legend (Button Style)', () => {
+    return (
+      <ElementsProvider>
+        <Map mapOptions={mapOptions} />
+        <LayerList
+          baseType='button'
+          layers={layers}
+          legend
+        />
+      </ElementsProvider>
+    );
+  })
   .add('With Data Driven Styles', () => {
     return (
       <ElementsProvider>

--- a/src/components/LayerList/LayerListItem.js
+++ b/src/components/LayerList/LayerListItem.js
@@ -14,7 +14,8 @@ const LayerListItem = ({
   legend,
   showActions,
   itemActions,
-  checkboxStyle
+  checkboxStyle,
+  baseType
 }) => {
   const [isChecked, setIsChecked] = useState(false);
   const [checkbox, setCheckbox] = useState(null);
@@ -90,9 +91,8 @@ const LayerListItem = ({
     let layerVisibility;
     let checked;
     if (mapExists(map)) {
-      if (Object.keys(map).length > 0) {
-        map.once('idle', () => {
-          layerVisibility = map.getLayoutProperty(layerIds[0], 'visibility');
+      const setCurrentState = () => {
+        layerVisibility = map.getLayoutProperty(layerIds[0], 'visibility');
           checked = layerVisibility !== 'none';
           setIsChecked(checked);
           if (legend) {
@@ -102,7 +102,23 @@ const LayerListItem = ({
                 : buildStyle(map.getLayer(layerIds[0]))
             );
           }
-        });
+      }
+      if (Object.keys(map).length > 0) {
+        if (baseType && baseType === 'button') {
+          try {
+            setCurrentState();
+          } catch (e) {
+            if (e instanceof TypeError) {
+              map.once('idle', () => {
+                setCurrentState();
+              });
+            }
+          }
+        } else {
+          map.once('idle', () => {
+            setCurrentState();
+          });
+        }
       }
     }
   }, [map, layerInfo]);


### PR DESCRIPTION
Issue was stemming from call if `map.once('idle', ... update state ...)`.  When baseType = 'button', this isn't called until after the map is moved.  This update is now called immediately for button baseTypes and still maintains the existing 'idle' callback for other baseTypes.