### PR TITLE
fix: data driven legend styles for Array of length > 1

### DIFF
--- a/src/components/LayerList/Legend.js
+++ b/src/components/LayerList/Legend.js
@@ -43,11 +43,11 @@ const buildStyle = (lyr) => {
 
     const Items = () => {
       let styles = [];
-      if (fc.length > 2) {
+      if (fc.length > 1) {
         styles = fc.map((l) => {
           return [...l, foc[0]];
         });
-      } else if (foc.length > 2) {
+      } else if (foc.length > 1) {
         styles = foc.map((l) => {
           return [...l, fc[0]];
         });


### PR DESCRIPTION
Builds data driven legends if length > 1.  Fixes errors where length == 2.