### PR TITLE
Feature/basemap switcher improvements

### DIFF
--- a/src/components/BasemapSwitcher/BasemapSwitcher.js
+++ b/src/components/BasemapSwitcher/BasemapSwitcher.js
@@ -15,6 +15,7 @@ import BaseComponent from '../_common/BaseComponent';
 const BasemapSwitcher = ({
   switcherStyle,
   basemaps,
+  preserveLayers, // array of objects, each with 'source' and 'layer' properties. see https://bl.ocks.org/ryanbaumann/7f9a353d0a1ae898ce4e30f336200483/96bea34be408290c161589dcebe26e8ccfa132d7
   baseType,
   buttonOptions,
   sx,
@@ -44,6 +45,28 @@ const BasemapSwitcher = ({
     if (mapExists(map)) {
       map.on('load', () => {
         map.setStyle(`mapbox://styles/mapbox/${basemapValue}`);
+        setTimeout(() => {
+          for (let i = 0; i < preserveLayers?.length; i += 1) {
+            const p = preserveLayers[i];
+            map.addSource(p.layer.source, p.source);
+            map.addLayer(p.layer);
+          }
+        }, 100);
+
+        map.on('style.load', () => {
+          const waiting = () => {
+            if (!map.isStyleLoaded()) {
+              setTimeout(waiting, 200);
+            } else {
+              for (let i = 0; i < preserveLayers?.length; i += 1) {
+                const p = preserveLayers[i];
+                map.addSource(p.layer.source, p.source);
+                map.addLayer(p.layer);
+              }
+            }
+          };
+          waiting();
+        });
       });
     }
   }, [map]);

--- a/src/components/BasemapSwitcher/BasemapSwitcher.js
+++ b/src/components/BasemapSwitcher/BasemapSwitcher.js
@@ -51,7 +51,7 @@ const BasemapSwitcher = ({
             map.addSource(p.layer.source, p.source);
             map.addLayer(p.layer);
           }
-        }, 100);
+        }, 200);
 
         map.on('style.load', () => {
           const waiting = () => {

--- a/src/components/BasemapSwitcher/BasemapSwitcher.js
+++ b/src/components/BasemapSwitcher/BasemapSwitcher.js
@@ -45,23 +45,18 @@ const BasemapSwitcher = ({
     if (mapExists(map)) {
       map.on('load', () => {
         map.setStyle(`mapbox://styles/mapbox/${basemapValue}`);
-        setTimeout(() => {
-          for (let i = 0; i < preserveLayers?.length; i += 1) {
-            const p = preserveLayers[i];
-            map.addSource(p.layer.source, p.source);
-            map.addLayer(p.layer);
-          }
-        }, 200);
 
-        map.on('style.load', () => {
+        map.on('styledata', () => {
           const waiting = () => {
             if (!map.isStyleLoaded()) {
               setTimeout(waiting, 200);
             } else {
               for (let i = 0; i < preserveLayers?.length; i += 1) {
                 const p = preserveLayers[i];
-                map.addSource(p.layer.source, p.source);
-                map.addLayer(p.layer);
+                if (!map.getSource(p.layer.source)) {
+                  map.addSource(p.layer.source, p.source);
+                  map.addLayer(p.layer);
+                }
               }
             }
           };

--- a/src/components/BasemapSwitcher/BasemapSwitcher.js
+++ b/src/components/BasemapSwitcher/BasemapSwitcher.js
@@ -76,7 +76,8 @@ const BasemapSwitcher = ({
       name: 'streets',
       key: 'streets',
       label: 'Streets',
-      value: 'streets-v11'
+      value: 'streets-v11',
+      checked: true
     },
     {
       name: 'terrain',

--- a/src/components/BasemapSwitcher/BasemapSwitcher.stories.js
+++ b/src/components/BasemapSwitcher/BasemapSwitcher.stories.js
@@ -37,23 +37,32 @@ const customMapOptions = Object.assign({}, mapOptions, {
 storiesOf('BasemapSwitcher', module)
   .addDecorator(withKnobs)
   .add('Default', () => {
-    const { map } = useElements();
-    useEffect(() => {
-      if (mapExists(map)) {
-        map.on('load', () => {
-          map.addSource(customLayers.layer.source, customLayers.source);
-          map.addLayer(customLayer.layer);
-        });
-      }
-    }, [map]);
+    const App = () => {
+      const { map } = useElements();
+      useEffect(() => {
+        if (mapExists(map)) {
+          map.on('load', () => {
+            customLayers.forEach(customLayer => {
+              map.addSource(customLayer.layer.source, customLayer.source);
+              map.addLayer(customLayer.layer);
+            });
+          });
+        }
+      }, [map]);
+      return (
+        <React.Fragment>
+          <Map mapOptions={customMapOptions} />
+          <BasemapSwitcher
+            preserveLayers={customLayers}
+            baseType={radios('baseType', ['none', 'panel', 'button'], 'panel')}
+            switcherStyle={radios('switcherStyle', ['radio', 'buttons'], 'radio')}
+          />
+        </React.Fragment>
+      );
+    };
     return (
       <ElementsProvider>
-        <Map mapOptions={customMapOptions} />
-        <BasemapSwitcher
-          preserveLayers={customLayers}
-          baseType={radios('baseType', ['none', 'panel', 'button'], 'panel')}
-          switcherStyle={radios('switcherStyle', ['radio', 'buttons'], 'radio')}
-        />
+        <App />
       </ElementsProvider>
     );
   })

--- a/src/components/BasemapSwitcher/BasemapSwitcher.stories.js
+++ b/src/components/BasemapSwitcher/BasemapSwitcher.stories.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import BasemapSwitcher from './BasemapSwitcher';
 import Map from '../Map/Map';
 import ElementsProvider from '../_common/ElementsProvider';
@@ -6,14 +6,51 @@ import { storiesOf } from '@storybook/react';
 import { withKnobs, radios } from '@storybook/addon-knobs';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import mapOptions from '../../util/mockMapOptions';
+import mapExists from '../../util/mapExists';
+import useElements from '../../util/useElements';
+
+const customLayers = [
+  {
+    source: {
+      type: 'geojson',
+      data:
+        'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_110m_admin_1_states_provinces_shp.geojson'
+    },
+    layer: {
+      id: 'states',
+      source: 'states',
+      type: 'line',
+      paint: {
+        'line-color': 'red',
+        'line-width': 2
+      }
+    }
+  }
+];
+
+const customMapOptions = Object.assign({}, mapOptions, {
+  center: [-100.207672, 39.581878],
+  zoom: 3,
+  bounds: null
+});
 
 storiesOf('BasemapSwitcher', module)
   .addDecorator(withKnobs)
   .add('Default', () => {
+    const { map } = useElements();
+    useEffect(() => {
+      if (mapExists(map)) {
+        map.on('load', () => {
+          map.addSource(customLayers.layer.source, customLayers.source);
+          map.addLayer(customLayer.layer);
+        });
+      }
+    }, [map]);
     return (
       <ElementsProvider>
-        <Map mapOptions={mapOptions} />
+        <Map mapOptions={customMapOptions} />
         <BasemapSwitcher
+          preserveLayers={customLayers}
           baseType={radios('baseType', ['none', 'panel', 'button'], 'panel')}
           switcherStyle={radios('switcherStyle', ['radio', 'buttons'], 'radio')}
         />

--- a/src/components/Draw/Draw.stories.js
+++ b/src/components/Draw/Draw.stories.js
@@ -9,7 +9,8 @@ import mapOptions from '../../util/mockMapOptions';
 
 const customMapOptions = Object.assign({}, mapOptions, {
   center: [-100.207672, 39.581878],
-  zoom: 3
+  zoom: 3,
+  bounds: null
 });
 
 storiesOf('Draw', module)

--- a/src/components/MapPopup/MapPopup.stories.js
+++ b/src/components/MapPopup/MapPopup.stories.js
@@ -10,7 +10,8 @@ import mapLayers from '../../util/mockMapLayers';
 
 const customMapOptions = Object.assign({}, mapOptions, {
   center: [-100.207672, 39.581878],
-  zoom: 3
+  zoom: 3,
+  bounds: null
 });
 
 const popupLayers = [
@@ -19,40 +20,46 @@ const popupLayers = [
     title: {
       field: 'ART_TYPE'
     },
-    attributes: [{
-      field: 'LOCATION',
-      label: 'Location',
-      type: 'text'
-    }, {
-      field: 'ARTIST',
-      label: 'Artist',
-      type: 'text'
-    }, {
-      field: 'TITLE',
-      label: 'Title',
-      type: 'text'
-    }]
+    attributes: [
+      {
+        field: 'LOCATION',
+        label: 'Location',
+        type: 'text'
+      },
+      {
+        field: 'ARTIST',
+        label: 'Artist',
+        type: 'text'
+      },
+      {
+        field: 'TITLE',
+        label: 'Title',
+        type: 'text'
+      }
+    ]
   },
   {
     layerId: 'football-stadiums-layer',
     title: {
       field: 'name1'
     },
-    attributes: [{
-      field: 'conference',
-      label: 'Conference',
-      type: 'text'
-    }]
+    attributes: [
+      {
+        field: 'conference',
+        label: 'Conference',
+        type: 'text'
+      }
+    ]
   },
   {
     layerId: 'states-layer', // id of layer on map
     title: {
       field: 'name'
     }, // popup title field
-    intercept: async function(properties) {
+    intercept: async function (properties) {
       // mock getting some external data
-      return new Promise(function(resolve, reject) {
-        setTimeout(function() {
+      return new Promise(function (resolve, reject) {
+        setTimeout(function () {
           resolve(Object.assign(properties, { source: 'intercept' }));
         }, 250);
       });
@@ -82,7 +89,7 @@ const popupLayers = [
         field: 'name',
         label: 'Image',
         type: 'image',
-        expression: function(val) {
+        expression: function (val) {
           return `https://raw.githubusercontent.com/tannerjt/state_images.json/master/images/${val
             .toLowerCase()
             .replace(' ', '_')}.jpg`;
@@ -99,7 +106,7 @@ const popupLayers = [
               `${feature.properties.name} in the "${feature.layer.id}" map layer `
             );
             setLoading(false);
-          }, 1500)
+          }, 1500);
         }
       }
     ]
@@ -112,9 +119,7 @@ storiesOf('Popup', module)
     return (
       <ElementsProvider>
         <Map mapOptions={customMapOptions} mapLayers={mapLayers} />
-        <MapPopup 
-          layers={popupLayers}  
-          disabled={boolean('Disabled', false)} />
+        <MapPopup layers={popupLayers} disabled={boolean('Disabled', false)} />
       </ElementsProvider>
     );
   })
@@ -122,10 +127,11 @@ storiesOf('Popup', module)
     return (
       <ElementsProvider>
         <Map mapOptions={customMapOptions} mapLayers={mapLayers} />
-        <MapPopup 
-          layers={popupLayers} 
+        <MapPopup
+          layers={popupLayers}
           disabled={boolean('Disabled', false)}
-          showActions />
+          showActions
+        />
       </ElementsProvider>
     );
   });

--- a/src/components/ScaleBar/ScaleBar.stories.js
+++ b/src/components/ScaleBar/ScaleBar.stories.js
@@ -8,7 +8,8 @@ import mapOptions from '../../util/mockMapOptions';
 
 const customMapOptions = Object.assign({}, mapOptions, {
   center: [-100.207672, 39.581878],
-  zoom: 3
+  zoom: 3,
+  bounds: null
 });
 
 const posLabel = 'position';

--- a/src/components/Select/Select.stories.js
+++ b/src/components/Select/Select.stories.js
@@ -10,7 +10,8 @@ import mapLayers from '../../util/mockMapLayers';
 
 const customMapOptions = Object.assign({}, mapOptions, {
   center: [-100.207672, 39.581878],
-  zoom: 3
+  zoom: 3,
+  bounds: null
 });
 
 const geojsonLayer = {

--- a/src/components/_primitives/RadioGroup.js
+++ b/src/components/_primitives/RadioGroup.js
@@ -41,6 +41,7 @@ const RadioGroup = (props) => {
             key={item.value}
             name={name}
             item={item}
+            defaultChecked={item.checked}
             checkedChanged={checkedValueChange}
           />
         );

--- a/src/components/_primitives/RadioGroupItem.js
+++ b/src/components/_primitives/RadioGroupItem.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Label, Radio } from 'theme-ui';
 
-const RadioGroupItem = props => {
+const RadioGroupItem = (props) => {
   const { name, item, defaultChecked, checkedChanged } = props;
 
   return (
@@ -31,7 +31,7 @@ const RadioGroupItem = props => {
             bg: 'highlight'
           }
         }}
-        onChange={e => checkedChanged(e, item)}
+        onChange={(e) => checkedChanged(e, item)}
       />
       <span>{item.label}</span>
     </Label>


### PR DESCRIPTION
Improves utility of Basemap Switcher component by providing a prop that allows devs to pass an array of layers and sources they want to preserve when switching mapbox styles. This is a fairly well-known issue with MapboxGL. We're still leaving the logic of how to define which layers should be preserved to the application devs, but this at least supports the basic use case.